### PR TITLE
enable ranks

### DIFF
--- a/overrides/local/ftbu/config.json
+++ b/overrides/local/ftbu/config.json
@@ -1,0 +1,44 @@
+{
+  "modules": {
+    "backups": true,
+    "auto_restart": true,
+    "chunk_claiming": true,
+    "chunk_loading": true,
+    "motd": true,
+    "starting_items": true,
+    "web_api": false
+  },
+  "backups": {
+    "backups_to_keep": 12,
+    "backup_timer": 2.0,
+    "compression_level": 1,
+    "folder": "./backups/",
+    "display_file_size": true,
+    "use_separate_thread": true,
+    "need_online_players": true
+  },
+  "general": {
+    "restart_timer": 0.0,
+    "safe_spawn": false,
+    "blocked_entities": [],
+    "ranks_enabled": true,
+    "spawn_area_in_sp": false,
+    "server_info_difficulty": true,
+    "server_info_mode": true
+  },
+  "login": {
+    "motd": [
+      {
+        "text": "Welcome to the server!"
+      }
+    ],
+    "starting_items": [
+      "minecraft:apple 16 0"
+    ]
+  },
+  "webapi": {
+    "port": 4509,
+    "autostart": true,
+    "output_map": false
+  }
+}

--- a/overrides/local/ftbu/ranks.json
+++ b/overrides/local/ftbu/ranks.json
@@ -1,0 +1,42 @@
+{
+  "default_rank": "Player",
+  "ranks": {
+    "Player": {
+      "parent": "",
+      "color": "white",
+      "prefix": "",
+      "badge": "",
+      "config": {
+        "ftbu.chunkloader.max_chunks": 50,
+        "ftbu.chunkloader.offline_timer": -1.0,
+        "ftbu.claims.break_whitelist": [
+          "OpenBlocks:grave"
+        ],
+        "ftbu.claims.dimension_blacklist": [
+          1
+        ],
+        "ftbu.claims.max_chunks": 100,
+        "ftbu.homes.max": 2
+      }
+    },
+    "Admin": {
+      "parent": "Player",
+      "color": "dark_green",
+      "prefix": "",
+      "badge": "",
+      "permissions": [
+        "-*"
+      ],
+      "config": {
+        "ftbu.chunkloader.max_chunks": 5000,
+        "ftbu.chunkloader.offline_timer": -1.0,
+        "ftbu.claims.break_whitelist": [
+          "*"
+        ],
+        "ftbu.claims.dimension_blacklist": [],
+        "ftbu.claims.max_chunks": 1000,
+        "ftbu.homes.max": 100
+      }
+    }
+  }
+}


### PR DESCRIPTION
I added two files as an example to show how to get the number of player homes allowed to 2.  I bet that the reason it didn't work was because after you make changes to ranks.json you need to edit config.json and set "ranks_enabled": true.

I didn't have your files to start with, so I wouldn't just use mine.  I'm just issue a pull to show an example that I got working on my server with FTB Unstable 
